### PR TITLE
Strings in option json should be encoded only if it is strictly a column name

### DIFF
--- a/columnencoder.h
+++ b/columnencoder.h
@@ -76,7 +76,7 @@ public:
 	static	std::string			decodeAll(const std::string & text) { return replaceAll(text, decodingMap(), encodedNames());  }
 
 			///Replace all occurences of columnNames in a string by their encoded versions in all json-names and string-values, regardless of word boundaries or parentheses.
-	static	void				encodeJson(Json::Value & json, bool replaceNames = false);
+	static	void				encodeJson(Json::Value & json, bool replaceNames = false, bool replaceStrict = false);
 
 			///Replace all occurences of encoded columnNames in a string by their decoded versions in all json-names and string-values, regardless of word boundaries or parentheses.
 	static	void				decodeJson(Json::Value & json, bool replaceNames = true);
@@ -87,8 +87,10 @@ private:
 	static	void 				_encodeColumnNamesinOptions(Json::Value & options, Json::Value & meta);
 
 private:
-	static	std::string			replaceAll(std::string		text, const std::map<std::string, std::string> & map, const std::vector<std::string> & names);
-	static	void				replaceAll(Json::Value &	json, const std::map<std::string, std::string> & map, const std::vector<std::string> & names, bool replaceNames);
+	static	std::string			replaceAll(std::string text, const std::map<std::string, std::string> & map, const std::vector<std::string> & names);
+	static  std::string			replaceAllStrict(const std::string & text, const std::map<std::string, std::string> & map);
+
+	static	void				replaceAll(Json::Value & json, const std::map<std::string, std::string> & map, const std::vector<std::string> & names, bool replaceNames, bool replaceStrict);
 	static	std::vector<size_t>	getPositionsColumnNameMatches(const std::string & text, const std::string & columnName);
 			void				collectExtraEncodingsFromMetaJson(const Json::Value & in, std::vector<std::string> & namesCollected) const;
 	static	void				sortVectorBigToSmall(std::vector<std::string> & vec);


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/INTERNAL-jasp/issues/1749
I have added an option in encodeJson (called by ColumnEmcoder::encodeColumnNamesinOptions, which is only called by the engine to encode the option json value) so that it encodes the column names only if a string in the json is entirely a column name (currently, if even a part of a string in the option json value is a column name, it is replaced by its encoded value).