### PR TITLE
include <cstdint> to fix compiling with gcc13

### DIFF
--- a/enumutilities.h
+++ b/enumutilities.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <cstdint>
 
 #ifdef JASP_USES_QT_HERE
 #include <QString>


### PR DESCRIPTION
will fix jaspBase [rcmd check ](https://github.com/shun2wang/jaspBase/actions/runs/9062177217)fail on Windows R4.4.0+ see:https://github.com/jasp-stats/jaspBase/pull/148. also fix jaspBase compile to install.