### PR TITLE
fix trim space while value is not unsigned char

### DIFF
--- a/stringutils.h
+++ b/stringutils.h
@@ -161,15 +161,15 @@ public:
 
 	// trim from start (in place)
 	static inline std::string ltrim(std::string &s) {
-		s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch) {
-			return !std::isspace(ch);
+		s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+			return !std::isspace(ch);	// see:https://en.cppreference.com/w/cpp/string/byte/isspace
 		}));
 		return s;
 	}
 
 	// trim from end (in place)
 	static inline std::string rtrim(std::string &s) {
-		s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) {
+		s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
 			return !std::isspace(ch);
 		}).base(), s.end());
 		return s;


### PR DESCRIPTION
Fix: https://github.com/jasp-stats/jasp-issues/issues/3074

According the best practices of https://en.cppreference.com/w/cpp/string/byte/isspace it was undefined if the value of ch is not representable as unsigned char.so the problem may not be entirely a defect of freexl.

Note: you may need a clean build of freexl with this [PR](https://github.com/jasp-stats/jasp-desktop/pull/5775) but not from conanfile.txt.